### PR TITLE
Fix recommendation template typo

### DIFF
--- a/costemailer/resources/OpenShiftRecommendationEmailTemplate.html
+++ b/costemailer/resources/OpenShiftRecommendationEmailTemplate.html
@@ -510,7 +510,7 @@
                                     <table class="rh-data-table" style="background-color:#F0F0F0;">
                                       <tbody>
                                       <tr>
-                                        <th role="rowheader" style="padding-left: 20px;">Limits CPU</th><th>Limits Memory</th><th>Requests Memory</th><th>Requests Memory</th>
+                                        <th role="rowheader" style="padding-left: 20px;">Limits CPU</th><th>Limits Memory</th><th>Requests CPU</th><th>Requests Memory</th>
                                       </tr>
                                       <tr>
                                         <td style="padding-left: 20px;">{{ item.current.limits.cpu }}</td><td>{{ item.current.limits.memory }}</td><td>{{ item.current.requests.cpu }}</td><td>{{ item.current.requests.memory }}</td>


### PR DESCRIPTION
The Current section had Request Memory heading twice and no Request CPU.

![image](https://github.com/user-attachments/assets/cb5de0ed-f3f1-4e77-99b8-74a91aba935b)
