### PR TITLE
[COST-5295] create and update virtual env in one layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,12 +43,10 @@ RUN INSTALL_PKGS="python3.11 python3.11-devel glibc-langpack-en gcc-c++ shadow-u
 # Create a Python virtual environment for use by any application to avoid
 # potential conflicts with Python packages preinstalled in the main Python
 # installation.
-RUN python3.11 -m venv /pipenv-venv
+RUN python3.11 -m venv /pipenv-venv \
+    && /pipenv-venv/bin/python -m pip install --upgrade pip setuptools \
+    && /pipenv-venv/bin/python -m pip install pipenv
 ENV PATH="/pipenv-venv/bin:$PATH"
-# Install pipenv into the virtual env
-RUN \
-    pip install --upgrade pip && \
-    pip install pipenv
 
 WORKDIR ${APP_ROOT}
 


### PR DESCRIPTION
This change removes a layer from the final image that contains versions of pip and setuptools that contain known vulnerabilities.

Ref:

- [COST-5295](https://issues.redhat.com/browse/COST-5295)
- [#4253](https://github.com/project-koku/koku/pull/4253)

